### PR TITLE
First pass at resolving errors for `standards/`

### DIFF
--- a/standards/non_fungible_token.js
+++ b/standards/non_fungible_token.js
@@ -1,4 +1,4 @@
-import {lru_cache} from 'functools';
+import lru_cache from 'lru-cache';
 import {Contract, ContractParameter, ContractStorage} from 'pytezos/michelson/contract';
 import {michelson_to_micheline} from 'pytezos/michelson/micheline';
 var _pj;
@@ -40,7 +40,7 @@ class NonFungibleTokenImpl extends Contract {
         return new ContractStorage(michelson_to_micheline(storage_tz));
     }
 }
-_pj.set_decorators(NonFungibleTokenImpl, {"parameter": [property, lru_cache({"maxsize": null})], "storage": [property, lru_cache({"maxsize": null})]});
+_pj.set_decorators(NonFungibleTokenImpl, {"parameter": [property, new lru_cache()], "storage": [property, new lru_cache()]});
 export {NonFungibleTokenImpl};
 
 //# sourceMappingURL=non_fungible_token.js.map

--- a/standards/non_fungible_token.js
+++ b/standards/non_fungible_token.js
@@ -1,6 +1,6 @@
 import lru_cache from 'lru-cache';
-import {Contract, ContractParameter, ContractStorage} from 'pytezos/michelson/contract';
-import {michelson_to_micheline} from 'pytezos/michelson/micheline';
+import {Contract, ContractParameter, ContractStorage} from '../michelson/contract';
+import {michelson_to_micheline} from '../michelson/micheline';
 var _pj;
 var parameter_tz, storage_tz;
 


### PR DESCRIPTION
- swap out python `lru_cache` for js `lru-cache` in `standards/`
- fix import paths for `standards/non_fungible_token`